### PR TITLE
Add Projector PyCharm Community Edition image

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -48,6 +48,7 @@ jobs:
         - 'filebrowser/filebrowser:v2'
         - 'ghcr.io/neuro-inc/base:latest'
         - 'ghcr.io/neuro-inc/docker-registry-frontend:latest'
+        - 'registry.jetbrains.team/p/prj/containers/projector-pycharm-c:latest'
     runs-on: ubuntu-latest
     steps:
     - name: Login ghcr.io


### PR DESCRIPTION
Adds https://lp.jetbrains.com/projector/ image for `platform-pipelines` which allows running PyCharm in web browser